### PR TITLE
Fix empty widget when reverseMonitorOrder is true

### DIFF
--- a/UnifiedTaskbar.qml
+++ b/UnifiedTaskbar.qml
@@ -73,7 +73,7 @@ PluginComponent {
                 }
                 if (currentGroup.length > 0) groups.push(currentGroup);
                 groups.reverse();
-                workspaces = groups.flat();
+                workspaces = [].concat.apply([], groups);
             }
             return workspaces.length > 0 ? workspaces : [];
         } else if (CompositorService.isHyprland) {


### PR DESCRIPTION
## Summary

- Replace `Array.prototype.flat()` (ES2019) with `[].concat.apply([], groups)` — the QML/QuickShell JS engine doesn't support `.flat()`, causing a TypeError that silently breaks `getWorkspaceList()` and renders the widget empty

Fixes #4

## Test plan

- [ ] Enable `allMonitors: true` and `reverseMonitorOrder: true` in plugin settings
- [ ] Have workspaces on multiple outputs (or multiple workspace groups)
- [ ] Verify the widget renders correctly and workspaces appear in reversed monitor order
- [ ] Verify `journalctl --user -u dms.service` shows no `TypeError: Property 'flat'` errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)