### PR TITLE
feat: add adjustable icon padding and item spacing settings

### DIFF
--- a/UnifiedTaskbar.qml
+++ b/UnifiedTaskbar.qml
@@ -424,8 +424,9 @@ PluginComponent {
                         property var wsData: modelData
                         property bool isActive: wsData ? wsData.isActive : false
 
-                        width: innerLayout.implicitWidth + root.iconPadding * 2
-                        height: root.widgetThickness
+                        readonly property real pillInset: Math.max(root.iconPadding, Theme.spacingXS)
+                        width: innerLayout.implicitWidth + pillInset * 2
+                        height: Math.max(root.widgetThickness, innerLayout.implicitHeight + pillInset * 2)
                         radius: root.filledPills ? Theme.cornerRadius : Theme.cornerRadius * 1.5
                         color: root.filledPills ? (isActive ? Theme.primary : Theme.surfaceTextAlpha) : "transparent"
                         border.width: root.filledPills ? 0 : (isActive ? 2 : 1)
@@ -490,7 +491,8 @@ PluginComponent {
 
                         anchors.horizontalCenter: parent.horizontalCenter
                         width: root.filledPills ? (root.widgetThickness - Theme.spacingS * 0.9) : root.iconCellSize
-                        height: root.filledPills ? Math.max(Math.round((root.iconCellSize + root.widgetThickness) / 2) + root.iconPadding * 2, innerLayoutV.implicitHeight + root.iconPadding * 2) : (innerLayoutV.implicitHeight + root.iconPadding * 2)
+                        readonly property real pillInset: Math.max(root.iconPadding, Theme.spacingXS)
+                        height: root.filledPills ? Math.max(Math.round((root.iconCellSize + root.widgetThickness) / 2) + pillInset * 2, innerLayoutV.implicitHeight + pillInset * 2) : (innerLayoutV.implicitHeight + pillInset * 2)
                         radius: root.filledPills ? Theme.cornerRadius : Theme.cornerRadius * 1.5
                         color: root.filledPills ? (isActive ? Theme.primary : Theme.surfaceTextAlpha) : "transparent"
                         border.width: root.filledPills ? 0 : (isActive ? 2 : 1)
@@ -563,8 +565,8 @@ PluginComponent {
             }
             readonly property real entryIconSize: Theme.barIconSize(root.barThickness, undefined, root.barConfig?.maximizeWidgetIcons, root.barConfig?.iconScale)
 
-            width: root.compactMode ? entryIconSize + root.itemSpacing * 2 : entryIconSize + root.itemSpacing * 3 + 120
-            height: entryIconSize + root.itemSpacing * 2
+            width: root.compactMode ? entryIconSize + root.iconPadding * 2 : entryIconSize + root.iconPadding * 3 + 120
+            height: Math.round((root.iconCellSize + root.widgetThickness) / 2)
 
             Rectangle {
                 id: entryBackground
@@ -581,7 +583,7 @@ PluginComponent {
                 IconImage {
                     id: appIcon
                     anchors.left: parent.left
-                    anchors.leftMargin: root.compactMode ? Math.round((parent.width - appEntry.entryIconSize) / 2) : root.itemSpacing
+                    anchors.leftMargin: root.compactMode ? Math.round((parent.width - appEntry.entryIconSize) / 2) : root.iconPadding
                     anchors.verticalCenter: parent.verticalCenter
                     width: appEntry.entryIconSize
                     height: appEntry.entryIconSize
@@ -603,7 +605,7 @@ PluginComponent {
 
                 DankIcon {
                     anchors.left: parent.left
-                    anchors.leftMargin: root.compactMode ? Math.round((parent.width - appEntry.entryIconSize) / 2) : root.itemSpacing
+                    anchors.leftMargin: root.compactMode ? Math.round((parent.width - appEntry.entryIconSize) / 2) : root.iconPadding
                     anchors.verticalCenter: parent.verticalCenter
                     size: appEntry.entryIconSize
                     name: "sports_esports"
@@ -628,7 +630,7 @@ PluginComponent {
 
                 StyledText {
                     anchors.left: appIcon.right
-                    anchors.leftMargin: root.itemSpacing
+                    anchors.leftMargin: root.iconPadding
                     anchors.right: parent.right
                     anchors.rightMargin: root.iconPadding
                     anchors.verticalCenter: parent.verticalCenter

--- a/UnifiedTaskbar.qml
+++ b/UnifiedTaskbar.qml
@@ -44,6 +44,9 @@ PluginComponent {
     readonly property bool reverseMonitorOrder: pluginData.reverseMonitorOrder ?? false
     readonly property bool filledPills: pluginData.filledPills ?? false
 
+    readonly property real iconPadding: pluginData.iconPadding !== undefined ? pluginData.iconPadding : Theme.spacingS
+    readonly property real itemSpacing: pluginData.itemSpacing !== undefined ? pluginData.itemSpacing : Theme.spacingXS
+
     readonly property real iconCellSize: widgetThickness - ((barConfig?.removeWidgetPadding ?? false) ? 0 : Theme.snap((barConfig?.widgetPadding ?? 12) * (widgetThickness / 30), 1)) * 2
 
     property int _desktopEntriesUpdateTrigger: 0
@@ -406,7 +409,7 @@ PluginComponent {
 
             Row {
                 id: hLayout
-                spacing: Theme.spacingXS
+                spacing: root.itemSpacing
                 anchors.centerIn: parent
 
                 Repeater {
@@ -421,7 +424,7 @@ PluginComponent {
                         property var wsData: modelData
                         property bool isActive: wsData ? wsData.isActive : false
 
-                        width: innerLayout.implicitWidth + Theme.spacingS * 2
+                        width: innerLayout.implicitWidth + root.iconPadding * 2
                         height: root.widgetThickness
                         radius: root.filledPills ? Theme.cornerRadius : Theme.cornerRadius * 1.5
                         color: root.filledPills ? (isActive ? Theme.primary : Theme.surfaceTextAlpha) : "transparent"
@@ -446,7 +449,7 @@ PluginComponent {
                         Row {
                             id: innerLayout
                             anchors.centerIn: parent
-                            spacing: Theme.spacingXS
+                            spacing: root.itemSpacing
 
                             Repeater {
                                 model: ScriptModel {
@@ -469,7 +472,7 @@ PluginComponent {
 
             Column {
                 id: vLayout
-                spacing: Theme.spacingS
+                spacing: root.iconPadding
                 width: parent.width
                 anchors.verticalCenter: parent.verticalCenter
 
@@ -487,7 +490,7 @@ PluginComponent {
 
                         anchors.horizontalCenter: parent.horizontalCenter
                         width: root.filledPills ? (root.widgetThickness - Theme.spacingS * 0.9) : root.iconCellSize
-                        height: root.filledPills ? Math.max(Math.round((root.iconCellSize + root.widgetThickness) / 2) + Theme.spacingS * 2, innerLayoutV.implicitHeight + Theme.spacingS * 2) : (innerLayoutV.implicitHeight + Theme.spacingS * 2)
+                        height: root.filledPills ? Math.max(Math.round((root.iconCellSize + root.widgetThickness) / 2) + root.iconPadding * 2, innerLayoutV.implicitHeight + root.iconPadding * 2) : (innerLayoutV.implicitHeight + root.iconPadding * 2)
                         radius: root.filledPills ? Theme.cornerRadius : Theme.cornerRadius * 1.5
                         color: root.filledPills ? (isActive ? Theme.primary : Theme.surfaceTextAlpha) : "transparent"
                         border.width: root.filledPills ? 0 : (isActive ? 2 : 1)
@@ -511,7 +514,7 @@ PluginComponent {
                         Column {
                             id: innerLayoutV
                             anchors.centerIn: parent
-                            spacing: Theme.spacingXS
+                            spacing: root.itemSpacing
 
                             Repeater {
                                 model: ScriptModel {
@@ -560,8 +563,8 @@ PluginComponent {
             }
             readonly property real entryIconSize: Theme.barIconSize(root.barThickness, undefined, root.barConfig?.maximizeWidgetIcons, root.barConfig?.iconScale)
 
-            width: root.compactMode ? entryIconSize + Theme.spacingXS * 2 : entryIconSize + Theme.spacingXS * 3 + 120
-            height: Math.round((root.iconCellSize + root.widgetThickness) / 2)
+            width: root.compactMode ? entryIconSize + root.itemSpacing * 2 : entryIconSize + root.itemSpacing * 3 + 120
+            height: entryIconSize + root.itemSpacing * 2
 
             Rectangle {
                 id: entryBackground
@@ -578,7 +581,7 @@ PluginComponent {
                 IconImage {
                     id: appIcon
                     anchors.left: parent.left
-                    anchors.leftMargin: root.compactMode ? Math.round((parent.width - appEntry.entryIconSize) / 2) : Theme.spacingXS
+                    anchors.leftMargin: root.compactMode ? Math.round((parent.width - appEntry.entryIconSize) / 2) : root.itemSpacing
                     anchors.verticalCenter: parent.verticalCenter
                     width: appEntry.entryIconSize
                     height: appEntry.entryIconSize
@@ -600,7 +603,7 @@ PluginComponent {
 
                 DankIcon {
                     anchors.left: parent.left
-                    anchors.leftMargin: root.compactMode ? Math.round((parent.width - appEntry.entryIconSize) / 2) : Theme.spacingXS
+                    anchors.leftMargin: root.compactMode ? Math.round((parent.width - appEntry.entryIconSize) / 2) : root.itemSpacing
                     anchors.verticalCenter: parent.verticalCenter
                     size: appEntry.entryIconSize
                     name: "sports_esports"
@@ -625,9 +628,9 @@ PluginComponent {
 
                 StyledText {
                     anchors.left: appIcon.right
-                    anchors.leftMargin: Theme.spacingXS
+                    anchors.leftMargin: root.itemSpacing
                     anchors.right: parent.right
-                    anchors.rightMargin: Theme.spacingS
+                    anchors.rightMargin: root.iconPadding
                     anchors.verticalCenter: parent.verticalCenter
                     visible: !root.compactMode
                     text: appEntry.windowTitle

--- a/UnifiedTaskbarSettings.qml
+++ b/UnifiedTaskbarSettings.qml
@@ -1,18 +1,10 @@
 import QtQuick
 import qs.Common
-import qs.Widgets
 import qs.Modules.Plugins
 
 PluginSettings {
+    id: root
     pluginId: "unifiedTaskbar"
-
-    StyledText {
-        width: parent.width
-        text: "Display"
-        font.pixelSize: Theme.fontSizeLarge
-        font.weight: Font.Bold
-        color: Theme.surfaceText
-    }
 
     ToggleSetting {
         settingKey: "compactMode"
@@ -47,5 +39,21 @@ PluginSettings {
         label: "Filled Pills (Vertical)"
         description: "Use solid filled workspace pills instead of outlined borders"
         defaultValue: false
+    }
+
+    SliderSetting {
+        settingKey: "iconPadding"
+        label: "Icon Padding"
+        minimum: 0
+        maximum: 20
+        defaultValue: 4
+    }
+
+    SliderSetting {
+        settingKey: "itemSpacing"
+        label: "Item Spacing"
+        minimum: 0
+        maximum: 20
+        defaultValue: 2
     }
 }

--- a/UnifiedTaskbarSettings.qml
+++ b/UnifiedTaskbarSettings.qml
@@ -45,7 +45,7 @@ PluginSettings {
         settingKey: "iconPadding"
         label: "Icon Padding"
         minimum: 0
-        maximum: 20
+        maximum: 10
         defaultValue: 4
     }
 
@@ -53,7 +53,7 @@ PluginSettings {
         settingKey: "itemSpacing"
         label: "Item Spacing"
         minimum: 0
-        maximum: 20
+        maximum: 10
         defaultValue: 2
     }
 }


### PR DESCRIPTION
This PR introduces two new settings to the Unified Taskbar plugin to allow users to customize the visual density of the taskbar:

1. **Icon Padding:** Controls the padding around the icon group within each workspace pill.
2. **Item Spacing:** Controls the spacing between individual app icons.

By setting these values to 0, users can achieve a "flush" look similar to the native Dank Bar, which is especially useful for vertical bar configurations or compact setups.

Changes:
- Added `iconPadding` and `itemSpacing` properties to `PluginComponent`.
- Replaced hardcoded theme spacings (`Theme.spacingS`, `Theme.spacingXS`) with these dynamic properties in both horizontal and vertical layouts.
- Updated `appEntryDelegate` dimensions to correctly collapse when spacing is set to 0.
- Added corresponding `SliderSetting` controls to the settings page.