### PR TITLE
fix: stop taskbar delegate recreation that blocked clicks

### DIFF
--- a/UnifiedTaskbar.qml
+++ b/UnifiedTaskbar.qml
@@ -232,6 +232,7 @@ PluginComponent {
                         appGroups.set(moddedId, {
                             "isGrouped": true,
                             "appId": moddedId,
+                            "entryKey": moddedId,
                             "windows": [],
                             "toplevel": w
                         });
@@ -240,9 +241,10 @@ PluginComponent {
                 });
                 entries = Array.from(appGroups.values());
             } else {
-                entries = wsWindows.map(w => ({
+                entries = wsWindows.map((w, idx) => ({
                     "isGrouped": false,
                     "appId": Paths.moddedAppId(w.appId || "unknown"),
+                    "entryKey": Paths.moddedAppId(w.appId || "unknown") + "::" + idx,
                     "windows": [w],
                     "toplevel": w
                 }));
@@ -455,6 +457,7 @@ PluginComponent {
                             Repeater {
                                 model: ScriptModel {
                                     values: wsPill.wsData ? wsPill.wsData.entries : []
+                                    objectProp: "entryKey"
                                 }
 
                                 delegate: appEntryDelegate
@@ -521,6 +524,7 @@ PluginComponent {
                             Repeater {
                                 model: ScriptModel {
                                     values: wsPillV.wsData ? wsPillV.wsData.entries : []
+                                    objectProp: "entryKey"
                                 }
 
                                 delegate: appEntryDelegate


### PR DESCRIPTION
## Problem

Taskbar items were hard to click while a window was "animating" — most reproducibly when a terminal ran a TUI with a progress spinner (e.g. Claude Code) that reflects the spinner into the window title.

## Root cause

The app-entry `Repeater`s inside each workspace pill used a `ScriptModel` with **no `objectProp`**. `groupByWorkspace()` returns freshly-built JS objects on every model rebuild, and the model rebuilds ~1×/sec even at idle (more when a window title churns, since the toplevel title participates in sort/identity in `CompositorService`). With no identity key, the model destroyed and recreated **every** `appEntry` delegate on each rebuild — tearing down each delegate's `MouseArea` out from under the pointer, so clicks landed on nothing.

A title-text repaint was the initial suspect but turned out to be a red herring; the damage was delegate teardown, not text reshaping.

## Fix

Give each entry a stable `entryKey` and set `objectProp: "entryKey"` on both the horizontal and vertical inner `ScriptModel`s, so delegates persist across rebuilds.

## Verification

Instrumented the live widget with delegate `Component.onCompleted`/`onDestruction` logging:

| Scenario | groupByWorkspace / 5s | delegates recreated / 5s |
|---|---|---|
| Before | 6 | **96** |
| After (idle) | 6 | **0** |
| After (title spinner running) | 25 | **0** |

Confirmed in the running shell: other taskbar entries and workspace pills stay clickable while a title spinner churns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)