### PR TITLE
chore: bump version to 1.1.1

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -2,7 +2,7 @@
     "id": "unifiedTaskbar",
     "name": "Unified Taskbar",
     "description": "Running apps grouped by workspace with per-workspace pills",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "author": "Joshua Landau",
     "type": "widget",
     "capabilities": ["dankbar-widget", "compositor-integration"],


### PR DESCRIPTION
Patch release covering the bug fixes merged since 1.1.0:

- #8 — conditionally evaluate compositor services for Niri compatibility
- #9 — stop taskbar delegate recreation that blocked clicks

No new features or settings. Bumps `plugin.json` `version` `1.1.0` → `1.1.1` so the change is picked up by the plugin registry / update flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)