### PR TITLE
fix: guard DwlService reference in groupedWorkspaces binding

### DIFF
--- a/UnifiedTaskbar.qml
+++ b/UnifiedTaskbar.qml
@@ -272,7 +272,7 @@ PluginComponent {
         NiriService.allWorkspaces;
         Hyprland.workspaces;
         I3.workspaces;
-        DwlService.stateChanged;
+        if (CompositorService.isDwl) DwlService.stateChanged;
         return groupByWorkspace();
     }
 


### PR DESCRIPTION
## Summary

- `groupedWorkspaces` (line 270–277) is a QML reactive binding that enumerates compositor service signals to set up dependencies. It includes `DwlService.stateChanged` unconditionally.
- `DwlService` is absent from some DMS builds (confirmed missing in `dms-cli-0.0.git.3860+`, where `/usr/share/quickshell/dms/Services/` ships only `CompositorService` and `NiriService`).
- Evaluating an undefined QML singleton throws `ReferenceError`, aborting the binding before `return groupByWorkspace()` — so `groupedWorkspaces` is `undefined` and the widget renders blank for all non-dwl compositors on those builds.
- Every other `DwlService` call in the file is already guarded by `CompositorService.isDwl` (lines 30, 101, 102, 110, 148, 167, 180, 200, 263). This PR applies the same guard to the one unguarded reference.

## Test plan

- [ ] Confirmed blank widget with `ReferenceError: DwlService is not defined` in journal on `dms-cli-0.0.git.3860` (niri compositor)
- [ ] After fix: no new `DwlService` errors in journal, widget displays correctly
- [ ] One-line change, no behavior change on dwl (guard evaluates to true, reactive dependency still wired)

🤖 Generated with [Claude Code](https://claude.com/claude-code)